### PR TITLE
Export RSWT and WriterT constructor

### DIFF
--- a/src/Control/Monad/Trans/RWS/CPS.hs
+++ b/src/Control/Monad/Trans/RWS/CPS.hs
@@ -33,7 +33,7 @@ module Control.Monad.Trans.RWS.CPS (
   mapRWS,
   withRWS,
   -- * The RWST monad transformer
-  RWST,
+  RWST(..),
   runRWST,
   evalRWST,
   execRWST,

--- a/src/Control/Monad/Trans/Writer/CPS.hs
+++ b/src/Control/Monad/Trans/Writer/CPS.hs
@@ -37,7 +37,7 @@ module Control.Monad.Trans.Writer.CPS (
   execWriter,
   mapWriter,
   -- * The WriterT monad transformer
-  WriterT,
+  WriterT(..),
   runWriterT,
   execWriterT,
   mapWriterT,

--- a/writer-cps-transformers.cabal
+++ b/writer-cps-transformers.cabal
@@ -3,7 +3,7 @@
 -- see: https://github.com/sol/hpack
 
 name:           writer-cps-transformers
-version:        0.1.1.0
+version:        0.1.1.1
 license:        BSD3
 license-file:   LICENSE
 tested-with:    GHC == 7.0.4, GHC == 7.2.2, GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1


### PR DESCRIPTION
Hi, thanks for creating this package, but I couldn't use it because the constructor isn't exported.
I think they are supposed to be exported. See

https://hackage.haskell.org/package/transformers-0.5.2.0/docs/src/Control.Monad.Trans.RWS.Strict.html

https://hackage.haskell.org/package/transformers-0.5.2.0/docs/src/Control.Monad.Trans.Writer.Strict.html