### PR TITLE
Compatibility with transformers 0.5.6

### DIFF
--- a/writer-cps-transformers.cabal
+++ b/writer-cps-transformers.cabal
@@ -18,16 +18,24 @@ source-repository head
   type: git
   location: https://github.com/minad/writer-cps-transformers
 
+flag transformers-0-5-6
+  default: True
+  manual: False
+  description: Use transformers 0.5.6 or later
+
 library
   build-depends:
-    base <6,
-    transformers >=0.4 && <0.6
+    base <6
+  if flag(transformers-0-5-6)
+    build-depends: transformers >= 0.5.6
+  else
+    build-depends: transformers >=0.4 && <0.5.6
+    exposed-modules:
+      Control.Monad.Trans.RWS.CPS
+      Control.Monad.Trans.RWS.CPS.Internal
+      Control.Monad.Trans.Writer.CPS
+      Control.Monad.Trans.Writer.CPS.Internal
   hs-source-dirs:
     src
   ghc-options: -Wall
-  exposed-modules:
-    Control.Monad.Trans.RWS.CPS
-    Control.Monad.Trans.RWS.CPS.Internal
-    Control.Monad.Trans.Writer.CPS
-    Control.Monad.Trans.Writer.CPS.Internal
   default-language: Haskell2010


### PR DESCRIPTION
This change makes it so that, when compiling against transformers 0.5.6
or later, no modules are exported from this package. This will fix, for
example, the build failure reported in minad/writer-cps-mtl#3.